### PR TITLE
Undefined Error when Using privateKey Args

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,8 +19,8 @@ function getOptions(uri, opts = {}) {
   opts.username    = opts.username || envOpts.username;
   opts.host        = opts.host || envOpts.host;
   // FIXME Not working with dsa keys
-  if (opts.privateKey && !opts.private_key.indexOf('dsa') > -1) {
-    opts.privateKey = fs.readFileSync(opts.private_key).toString('utf-8');
+  if (opts.privateKey && !opts.privateKey.indexOf('dsa') > -1) {
+    opts.privateKey = fs.readFileSync(opts.privateKey).toString('utf-8');
   }
   // Use SSH-Agent
   if (!opts.agent && process.env.SSH_AUTH_SOCK) {


### PR DESCRIPTION
```
shell.ssh(HOST, {privateKey : <PATH_TO_IDENTITY_FILE>});
```

Using this plugin w/ a private key led to the following error:

```
node_modules/ssh2-client/build/lib/utils.js:30
  if (opts.privateKey && !opts.private_key.indexOf('dsa') > -1) {
                                          ^

TypeError: Cannot read property 'indexOf' of undefined
    at Object.getOptions (/home/jim/Scratch/south-cli/node_modules/ssh2-client/build/lib/utils.js:30:43)
    at getClient (/home/jim/Scratch/south-cli/node_modules/ssh2-client/build/lib/client.js:11:26)
    at Object.shell (/home/jim/Scratch/south-cli/node_modules/ssh2-client/build/lib/shell.js:8:10)
    at Object.<anonymous> (/home/jim/Scratch/south-cli/node_modules/shelljs-plugin-ssh/bin/shell.js:9:4)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
```
